### PR TITLE
implements docs and tests for algorithms

### DIFF
--- a/docs/src/AlgList.md
+++ b/docs/src/AlgList.md
@@ -10,3 +10,11 @@ MetaheuristicsAlgorithms.DSO
 MetaheuristicsAlgorithms.AEO
 ```
 
+```@docs 
+MetaheuristicsAlgorithms.AFT
+```
+
+
+```@docs 
+MetaheuristicsAlgorithms.AHA
+```

--- a/docs/src/AlgList.md
+++ b/docs/src/AlgList.md
@@ -5,3 +5,8 @@
 ```@docs
 MetaheuristicsAlgorithms.DSO
 ```
+
+```@docs 
+MetaheuristicsAlgorithms.AEO
+```
+

--- a/src/AEO.jl
+++ b/src/AEO.jl
@@ -1,10 +1,36 @@
-"""
-Zhao, Weiguo, Liying Wang, and Zhenxing Zhang. 
-"Artificial ecosystem-based optimization: a novel nature-inspired meta-heuristic algorithm." 
-Neural Computing and Applications 32, no. 13 (2020): 9383-9425.
-"""
+struct AEOResult <: OptimizationResult
+    BestF
+    BestX
+    HisBestFit
+end 
 
-function AEO(nPop, MaxIt, Low, Up, Dim, F_index)
+"""
+    AEO(nPop, MaxIt, Low, Up, F_index)
+
+    Artificial Ecosystem-based Optimization (AEO) algorithm implementation in Julia.
+
+# Arguments:
+
+- `nPop`: Number of individuals in the population.
+- `MaxIt`: Maximum number of iterations.
+- `Low`: Lower bounds for the search space.
+- `Up`: Upper bounds for the search space.
+- `F_index`: Function to evaluate the fitness of individuals.
+
+# Returns:
+
+- `AEOResult`: A struct containing:
+  - `BestF`: The best fitness value found.
+  - `BestX`: The position corresponding to the best fitness.
+  - `HisBestFit`: A vector of best fitness values at each iteration.
+
+# References: 
+
+- Zhao, Weiguo, Liying Wang, and Zhenxing Zhang. "Artificial ecosystem-based optimization: a novel nature-inspired meta-heuristic algorithm." Neural Computing and Applications 32, no. 13 (2020): 9383-9425.
+"""
+function AEO(nPop::Int, MaxIt::Int, Low::Vector, Up::Vector, F_index)::AEOResult
+
+    Dim = length(Low)
     PopPos = zeros(nPop, Dim)
     PopFit = zeros(nPop)
 
@@ -85,5 +111,9 @@ function AEO(nPop, MaxIt, Low, Up, Dim, F_index)
         HisBestFit[It] = BestF
     end
 
-    return BestF, BestX, HisBestFit
+    #return BestF, BestX, HisBestFit
+    return AEOResult(
+        BestF, 
+        BestX, 
+        HisBestFit)
 end

--- a/src/AFT.jl
+++ b/src/AFT.jl
@@ -1,10 +1,36 @@
-"""
-Braik, Malik, Mohammad Hashem Ryalat, and Hussein Al-Zoubi. 
-"A novel meta-heuristic algorithm for solving numerical optimization problems: Ali Baba and the forty thieves." 
-Neural Computing and Applications 34, no. 1 (2022): 409-455.
-"""
+struct AFTResult <: OptimizationResult
+    fitness
+    gbest
+    ccurve
+end 
 
-function AFT(noThieves, itemax, lb, ub, dim, fobj)
+"""
+    AFT(noThieves, itemax, lb, ub, fobj)
+
+The Ali Baba and the Forty Thieves (AFT) algorithm is a meta-heuristic optimization algorithm inspired by the story of Ali Baba and the Forty Thieves. It is designed to solve numerical optimization problems by simulating the behavior of thieves searching for treasures.
+
+# Arguments:
+
+- `noThieves`: Number of thieves in the algorithm.
+- `itemax`: Maximum number of iterations.
+- `lb`: Lower bounds for the search space.
+- `ub`: Upper bounds for the search space.
+- `fobj`: Objective function to evaluate the fitness of solutions.
+
+# Returns: 
+
+- `AFTResult`: A struct containing:
+  - `fitness`: The best fitness value found.
+  - `gbest`: The position corresponding to the best fitness.
+  - `ccurve`: A vector of best fitness values at each iteration.
+
+# References:
+
+- Braik, Malik, Mohammad Hashem Ryalat, and Hussein Al-Zoubi. "A novel meta-heuristic algorithm for solving numerical optimization problems: Ali Baba and the forty thieves." Neural Computing and Applications 34, no. 1 (2022): 409-455.
+"""
+function AFT(noThieves, itemax, lb, ub, fobj)
+
+    dim = length(lb)  # Dimension of the problem
 
     ccurve = zeros(1, itemax)
 
@@ -74,5 +100,9 @@ function AFT(noThieves, itemax, lb, ub, dim, fobj)
     gbestSol = best[bestThieves[1], :]
     fitness = fobj(gbestSol)
 
-    return fitness, gbest, ccurve
+    #return fitness, gbest, ccurve
+    return AFTResult(
+        fitness, 
+        gbestSol, 
+        ccurve)
 end

--- a/src/AHA.jl
+++ b/src/AHA.jl
@@ -1,13 +1,38 @@
-"""
-Zhao, Weiguo, Liying Wang, and Seyedali Mirjalili. 
-"Artificial hummingbird algorithm: A new bio-inspired optimizer with its engineering applications." 
-Computer Methods in Applied Mechanics and Engineering 388 (2022): 114194.
+
+struct AHAResult <: OptimizationResult 
+    BestF
+    BestX
+    HisBestFit
+end
+
 """
 
-using Random
+    AHA(nPop, MaxIt, Low, Up, FunIndex)
 
-function AHA(nPop, MaxIt, Low, Up, Dim, FunIndex)#(FunIndex, MaxIt, nPop)
+The Artificial Hummingbird Algorithm (AHA) is a meta-heuristic optimization algorithm inspired by the foraging behavior of hummingbirds. It is designed to solve numerical optimization problems by simulating the way hummingbirds search for food.
+
+# Arguments:
+
+- `nPop`: Number of hummingbirds (population size).
+- `MaxIt`: Maximum number of iterations.
+- `Low`: Lower bounds for the search space.
+- `Up`: Upper bounds for the search space.
+- `FunIndex`: Objective function to evaluate the fitness of solutions.
+
+# Returns:
+- `AHAResult`: A struct containing:
+  - `BestF`: The best fitness value found.
+  - `BestX`: The position corresponding to the best fitness.
+  - `HisBestFit`: A vector of best fitness values at each iteration.
+
+# References: 
+
+- Zhao, Weiguo, Liying Wang, and Seyedali Mirjalili. "Artificial hummingbird algorithm: A new bio-inspired optimizer with its engineering applications." Computer Methods in Applied Mechanics and Engineering 388 (2022): 114194.
+"""
+function AHA(nPop, MaxIt, Low, Up, FunIndex)::AHAResult
     
+    Dim = length(Low)
+
     PopPos = rand(nPop, Dim) .* (Up .- Low) .+ Low
     PopFit = zeros(nPop)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,30 +6,6 @@ include("benchmark.jl")
 
 include("testbenchmark.jl")
 include("testdso.jl")
+include("testaeo.jl")
 
-@testset "MetaheuristicsAlgorithms.jl" begin
-    @testset "AEFA on Eggholder function" begin
-        Random.seed!(1)
-        lb = [-512, -512]
-        ub = [512, 512]
-        algo = AEFA(100, 300, lb, ub)
 
-        while algo.update
-            y = benchmark(algo.x; funNo=1)
-            update_state!(algo, y)
-        end
-        @test algo.gbest == [-461.648054120324, -390.06329199871277]
-        @test algo.gbest_val[end] == -775.8393103361666
-    end
-
-    # @testset "AEO on Eggholder function" begin
-    #     Random.seed!(1)
-    #     lb = [-512, -512]
-    #     ub = [512, 512]
-    #     fun(x) = first(benchmark(x))
-    #     BestF, BestX, _ = AEO(100, 300, lb, ub, 2, fun)
-
-    #     @test BestF == -959.640662720851
-    #     @test BestX == [512.0, 404.2318050941216]
-    # end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,8 @@ include("benchmark.jl")
 include("testbenchmark.jl")
 include("testdso.jl")
 include("testaeo.jl")
+include("testaha.jl")
+include("testaft.jl")
+
 
 

--- a/test/testaeo.jl
+++ b/test/testaeo.jl
@@ -1,0 +1,23 @@
+@testset "AEO" verbose = true begin 
+    @testset "Ackley with AEO, p = 2" verbose = true begin 
+        lb = [-32.768 for i in 1:2]
+        ub = [32.768 for i in 1:2]
+        result = AEO(100, 500, lb, ub, Ackley)
+        @test isapprox(result.BestX, [0.0 for i in 1:2], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end 
+    @testset "Ackley with AEO, p = 5" verbose = true begin 
+        lb = [-32.768 for i in 1:5]
+        ub = [32.768 for i in 1:5]
+        result = AEO(100, 500, lb, ub, Ackley)
+        @test isapprox(result.BestX, [0.0 for i in 1:5], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end
+    @testset "Griewank with AEO, p = 2" verbose = true begin 
+        lb = [-600 for i in 1:2]
+        ub = [600 for i in 1:2]
+        result = AEO(100, 500, lb, ub, Griewank)
+        @test isapprox(result.BestX, [0.0 for i in 1:2], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end
+end 

--- a/test/testaft.jl
+++ b/test/testaft.jl
@@ -1,0 +1,24 @@
+@testset "AFT" verbose = true begin 
+    @warn "AFT tests are failing, please check the implementation."
+    @testset "Ackley with AFT, p = 5" verbose = true begin 
+        lb = [-32.768 for i in 1:5]
+        ub = [32.768 for i in 1:5]
+        result = AFT(5, 0, lb, ub,Ackley)
+        @test isapprox(result.gbest, [0.0 for i in 1:5], atol=1e-5)
+        @test isapprox(result.fitness, 0.0, atol=1e-5)
+    end 
+    @testset "Ackley with AFT, p = 10" verbose = true begin 
+        lb = [-32.768 for i in 1:10]
+        ub = [32.768 for i in 1:10]
+        result = AFT(5, 5000, lb, ub, Ackley)
+        @test isapprox(result.gbest, [0.0 for i in 1:10], atol=1e-5)
+        @test isapprox(result.fitness, 0.0, atol=1e-5)
+    end
+    @testset "Griewank with AFT, p = 2" verbose = true begin 
+        lb = [-600 for i in 1:2]
+        ub = [600 for i in 1:2]
+        result = AFT(2, 5000, lb, ub, Griewank)
+        @test isapprox(result.gbest, [0.0 for i in 1:2], atol=1e-5)
+        @test isapprox(result.fitness, 0.0, atol=1e-5)
+    end
+end 

--- a/test/testaha.jl
+++ b/test/testaha.jl
@@ -1,0 +1,24 @@
+@testset "AHA" verbose = true begin 
+    @warn "AHA tests are failing, please check the implementation."
+    @testset "Ackley with AHA, p = 2" verbose = true begin 
+        lb = [-32.768 for i in 1:2]
+        ub = [32.768 for i in 1:2]
+        result = AHA(100, 1500, lb, ub, Ackley)
+        @test isapprox(result.BestX, [0.0 for i in 1:2], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end 
+    @testset "Ackley with AHA, p = 5" verbose = true begin 
+        lb = [-32.768 for i in 1:5]
+        ub = [32.768 for i in 1:5]
+        result = AHA(100, 1500, lb, ub, Ackley)
+        @test isapprox(result.BestX, [0.0 for i in 1:5], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end
+    @testset "Griewank with AHA, p = 2" verbose = true begin 
+        lb = [-600 for i in 1:2]
+        ub = [600 for i in 1:2]
+        result = AHA(100, 1500, lb, ub, Griewank)
+        @test isapprox(result.BestX, [0.0 for i in 1:2], atol=1e-5)
+        @test isapprox(result.BestF, 0.0, atol=1e-5)
+    end
+end 

--- a/test/testbenchmark.jl
+++ b/test/testbenchmark.jl
@@ -1,21 +1,23 @@
-@testset "Test Ackley" verbose = true begin
-    @testset "Ackley, p = 2" verbose = true begin
-        result = Ackley([0.0, 0.0])
-        @test isapprox(result, 0.0, atol=1e-5)
+@testset "Benchmark Functions" verbose = true begin
+    @testset "Test Ackley" verbose = true begin
+        @testset "Ackley, p = 2" verbose = true begin
+            result = Ackley([0.0, 0.0])
+            @test isapprox(result, 0.0, atol=1e-5)
+        end
+        @testset "Ackley, p = 5" verbose = true begin
+            result = Ackley([0.0, 0.0, 0.0, 0.0, 0.0])
+            @test isapprox(result, 0.0, atol=1e-5)
+        end
     end
-    @testset "Ackley, p = 5" verbose = true begin
-        result = Ackley([0.0, 0.0, 0.0, 0.0, 0.0])
-        @test isapprox(result, 0.0, atol=1e-5)
-    end
-end
 
-@testset "Test Griewank" verbose = true begin
-    @testset "Griewank, p = 2" verbose = true begin
-        result = Griewank([0.0, 0.0])
-        @test isapprox(result, 0.0, atol=1e-5)
-    end
-    @testset "Griewank, p = 5" verbose = true begin
-        result = Griewank([0.0, 0.0, 0.0, 0.0, 0.0])
-        @test isapprox(result, 0.0, atol=1e-5)
+    @testset "Test Griewank" verbose = true begin
+        @testset "Griewank, p = 2" verbose = true begin
+            result = Griewank([0.0, 0.0])
+            @test isapprox(result, 0.0, atol=1e-5)
+        end
+        @testset "Griewank, p = 5" verbose = true begin
+            result = Griewank([0.0, 0.0, 0.0, 0.0, 0.0])
+            @test isapprox(result, 0.0, atol=1e-5)
+        end
     end
 end


### PR DESCRIPTION
Note that tests for AHA and AFT are not passing for Ackley and some other benchmark functions.

Since I don't how those algorithms work, I left them as they are. A special care is required. 

The documentation will appear in the page 

https://abdelazimhussien.github.io/MetaheuristicsAlgorithms.jl/dev/AlgList.html

once the PR is merged.

A second note for documentation: The docstring and the function definition will be adjacent, that is, if we put a line between the docstring and the function definition, the documentation will not include the aforementioned docs. 

The second issue is the `dim` parameter. I think when the `Ub` (Upper bounds) and `Lb` (Lower bounds), no one needs the specific dim parameter just because these vectors hold the length as the problem dimensionality.

You can now iterate the same design pattern for the remaining algorithms.